### PR TITLE
remove "by using"

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -10,28 +10,28 @@
 :page-layout: guide-multipane
 :page-duration: 30 minutes
 :page-releasedate: 2022-04-05
-:page-description: Explore how to deploy a microservice to Kubernetes by using Open Liberty Operator.
+:page-description: Explore how to deploy a microservice to Kubernetes using Open Liberty Operator.
 :page-tags: ['Kubernetes', 'Docker', 'Cloud'] 
 :page-permalink: /guides/{projectid}
 :page-related-guides: ['cloud-openshift', 'cloud-openshift-operator', 'okd']
 :common-includes: https://raw.githubusercontent.com/OpenLiberty/guides-common/prod
 :imagesdir: /img/guide/{projectid}
 :source-highlighter: prettify
-:page-seo-title: Deploying a microservice to Kubernetes by using Open Liberty Operator
+:page-seo-title: Deploying a microservice to Kubernetes using Open Liberty Operator
 :page-seo-description: A getting started tutorial with examples on how to deploy a cloud-native Java application and a microservice to a Kubernetes cluster by using a Kubernetes Operator like the Open Liberty Operator.
 :guide-author: Open Liberty
-= Deploying a microservice to Kubernetes by using Open Liberty Operator
+= Deploying a microservice to Kubernetes using Open Liberty Operator
 
 [.hidden]
 NOTE: This repository contains the guide documentation source. To view the guide in published form, view it on the https://openliberty.io/guides/{projectid}.html[Open Liberty website^].
 
-Explore how to deploy a microservice to Kubernetes by using Open Liberty Operator.
+Explore how to deploy a microservice to Kubernetes using Open Liberty Operator.
 
 :kube: Kubernetes
 
 == What you'll learn
 
-You will learn how to deploy a cloud-native application with a microservice to Kubernetes by using the Open Liberty Operator. 
+You will learn how to deploy a cloud-native application with a microservice to Kubernetes using the Open Liberty Operator. 
 
 https://www.kubernetes.io/[Kubernetes^] is a container orchestration system. It streamlines the DevOps process by providing an intuitive development pipeline. It also provides integration with multiple tools to make the deployment and management of cloud applications easier. You can learn more about Kubernetes by checking out the https://openliberty.io/guides/kubernetes-intro.html[Deploying microservices to Kubernetes^] guide.
 


### PR DESCRIPTION
Removed "by" from "by using" in the title and first sentence. It's fine elsewhere in the body of the guide where it tends to be in the context of longer sentences and is useful for disambiguation. But in the title it reads oddly/clunkily and it's not how it would be said normally.